### PR TITLE
feat(auth): add auth foundation with jwt and user profile

### DIFF
--- a/backend/src/main/java/com/bjtu/dining/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.bjtu.dining.auth.controller;
+
+import com.bjtu.dining.auth.dto.LoginRequest;
+import com.bjtu.dining.auth.dto.RegisterRequest;
+import com.bjtu.dining.auth.service.AuthService;
+import com.bjtu.dining.auth.vo.LoginResponse;
+import com.bjtu.dining.auth.vo.RegisterResponse;
+import com.bjtu.dining.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ApiResponse<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        return ApiResponse.success(authService.register(request));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ApiResponse.success(authService.login(request));
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/dto/LoginRequest.java
@@ -1,0 +1,30 @@
+package com.bjtu.dining.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class LoginRequest {
+    @NotBlank(message = "用户名不能为空")
+    @Size(max = 50, message = "用户名长度不能超过 50 位")
+    private String username;
+
+    @NotBlank(message = "密码不能为空")
+    @Size(min = 6, max = 100, message = "密码长度必须在 6 到 100 位之间")
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/dto/RegisterRequest.java
@@ -1,0 +1,42 @@
+package com.bjtu.dining.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+    @NotBlank(message = "用户名不能为空")
+    @Size(max = 50, message = "用户名长度不能超过 50 位")
+    private String username;
+
+    @NotBlank(message = "密码不能为空")
+    @Size(min = 6, max = 100, message = "密码长度不能少于 6 位")
+    private String password;
+
+    @NotBlank(message = "昵称不能为空")
+    @Size(max = 50, message = "昵称长度不能超过 50 位")
+    private String nickname;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/security/AuthUserContext.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/security/AuthUserContext.java
@@ -1,0 +1,19 @@
+package com.bjtu.dining.auth.security;
+
+import com.bjtu.dining.common.enums.ErrorCode;
+import com.bjtu.dining.common.exception.BusinessException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class AuthUserContext {
+    private AuthUserContext() {
+    }
+
+    public static Long currentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof AuthUserPrincipal principal)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return principal.userId();
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/security/AuthUserPrincipal.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/security/AuthUserPrincipal.java
@@ -1,0 +1,4 @@
+package com.bjtu.dining.auth.security;
+
+public record AuthUserPrincipal(Long userId, String username) {
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/security/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.bjtu.dining.auth.security;
+
+import com.bjtu.dining.common.enums.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    public static final String AUTH_ERROR_CODE_ATTRIBUTE = "authErrorCode";
+
+    private final JwtTokenService jwtTokenService;
+
+    public JwtAuthenticationFilter(JwtTokenService jwtTokenService) {
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (!StringUtils.hasText(authorization) || !authorization.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorization.substring(7).trim();
+        if (!StringUtils.hasText(token)) {
+            request.setAttribute(AUTH_ERROR_CODE_ATTRIBUTE, ErrorCode.UNAUTHORIZED);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            AuthUserPrincipal principal = jwtTokenService.parse(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, token, Collections.emptyList());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (ExpiredJwtException ex) {
+            SecurityContextHolder.clearContext();
+            request.setAttribute(AUTH_ERROR_CODE_ATTRIBUTE, ErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException ex) {
+            SecurityContextHolder.clearContext();
+            request.setAttribute(AUTH_ERROR_CODE_ATTRIBUTE, ErrorCode.UNAUTHORIZED);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/security/JwtProperties.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/security/JwtProperties.java
@@ -1,0 +1,27 @@
+package com.bjtu.dining.auth.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "app.security.jwt")
+public class JwtProperties {
+    private String secret = "bjtu-dining-simulation-system-jwt-secret-key-2026";
+    private long expireSeconds = 7200L;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public long getExpireSeconds() {
+        return expireSeconds;
+    }
+
+    public void setExpireSeconds(long expireSeconds) {
+        this.expireSeconds = expireSeconds;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/security/JwtTokenService.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/security/JwtTokenService.java
@@ -1,0 +1,55 @@
+package com.bjtu.dining.auth.security;
+
+import com.bjtu.dining.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtTokenService {
+    private final JwtProperties jwtProperties;
+    private final SecretKey secretKey;
+
+    public JwtTokenService(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createToken(User user) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(jwtProperties.getExpireSeconds());
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getUserId()))
+                .claim("username", user.getUsername())
+                .claim("nickname", user.getNickname())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiresAt))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public AuthUserPrincipal parse(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        String subject = claims.getSubject();
+        if (subject == null) {
+            throw new IllegalArgumentException("Token 中缺少用户标识");
+        }
+        return new AuthUserPrincipal(Long.valueOf(subject), claims.get("username", String.class));
+    }
+
+    public long getExpireSeconds() {
+        return jwtProperties.getExpireSeconds();
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.bjtu.dining.auth.service;
+
+import com.bjtu.dining.auth.dto.LoginRequest;
+import com.bjtu.dining.auth.dto.RegisterRequest;
+import com.bjtu.dining.auth.vo.LoginResponse;
+import com.bjtu.dining.auth.vo.RegisterResponse;
+
+public interface AuthService {
+    RegisterResponse register(RegisterRequest request);
+
+    LoginResponse login(LoginRequest request);
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,91 @@
+package com.bjtu.dining.auth.service.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.bjtu.dining.auth.dto.LoginRequest;
+import com.bjtu.dining.auth.security.JwtTokenService;
+import com.bjtu.dining.auth.dto.RegisterRequest;
+import com.bjtu.dining.auth.service.AuthService;
+import com.bjtu.dining.auth.vo.LoginResponse;
+import com.bjtu.dining.auth.vo.LoginUserResponse;
+import com.bjtu.dining.auth.vo.RegisterResponse;
+import com.bjtu.dining.common.enums.ErrorCode;
+import com.bjtu.dining.common.exception.BusinessException;
+import com.bjtu.dining.user.entity.User;
+import com.bjtu.dining.user.mapper.UserMapper;
+import com.bjtu.dining.wallet.entity.Wallet;
+import com.bjtu.dining.wallet.mapper.WalletMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+    private final UserMapper userMapper;
+    private final WalletMapper walletMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenService jwtTokenService;
+
+    public AuthServiceImpl(UserMapper userMapper,
+                           WalletMapper walletMapper,
+                           PasswordEncoder passwordEncoder,
+                           JwtTokenService jwtTokenService) {
+        this.userMapper = userMapper;
+        this.walletMapper = walletMapper;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Override
+    @Transactional
+    public RegisterResponse register(RegisterRequest request) {
+        String username = request.getUsername().trim();
+        String nickname = request.getNickname().trim();
+
+        if (userMapper.selectCount(
+                Wrappers.<User>lambdaQuery().eq(User::getUsername, username)
+        ) > 0) {
+            throw new BusinessException(ErrorCode.USERNAME_EXISTS);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setNickname(nickname);
+        user.setAvatarUrl("");
+        user.setCreateTime(now);
+        user.setUpdateTime(now);
+        userMapper.insert(user);
+
+        Wallet wallet = new Wallet();
+        wallet.setUserId(user.getUserId());
+        wallet.setBalance(BigDecimal.ZERO);
+        wallet.setUpdateTime(now);
+        walletMapper.insert(wallet);
+
+        return new RegisterResponse(user.getUserId(), user.getUsername(), user.getNickname());
+    }
+
+    @Override
+    public LoginResponse login(LoginRequest request) {
+        String username = request.getUsername().trim();
+
+        User user = userMapper.selectOne(
+                Wrappers.<User>lambdaQuery().eq(User::getUsername, username)
+        );
+        if (user == null || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String token = jwtTokenService.createToken(user);
+        return new LoginResponse(
+                token,
+                jwtTokenService.getExpireSeconds(),
+                LoginUserResponse.from(user)
+        );
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/vo/LoginResponse.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/vo/LoginResponse.java
@@ -1,0 +1,25 @@
+package com.bjtu.dining.auth.vo;
+
+public class LoginResponse {
+    private final String token;
+    private final long expiresIn;
+    private final LoginUserResponse user;
+
+    public LoginResponse(String token, long expiresIn, LoginUserResponse user) {
+        this.token = token;
+        this.expiresIn = expiresIn;
+        this.user = user;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public long getExpiresIn() {
+        return expiresIn;
+    }
+
+    public LoginUserResponse getUser() {
+        return user;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/vo/LoginUserResponse.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/vo/LoginUserResponse.java
@@ -1,0 +1,31 @@
+package com.bjtu.dining.auth.vo;
+
+import com.bjtu.dining.user.entity.User;
+
+public class LoginUserResponse {
+    private final Long userId;
+    private final String username;
+    private final String nickname;
+
+    public LoginUserResponse(Long userId, String username, String nickname) {
+        this.userId = userId;
+        this.username = username;
+        this.nickname = nickname;
+    }
+
+    public static LoginUserResponse from(User user) {
+        return new LoginUserResponse(user.getUserId(), user.getUsername(), user.getNickname());
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/auth/vo/RegisterResponse.java
+++ b/backend/src/main/java/com/bjtu/dining/auth/vo/RegisterResponse.java
@@ -1,0 +1,25 @@
+package com.bjtu.dining.auth.vo;
+
+public class RegisterResponse {
+    private final Long userId;
+    private final String username;
+    private final String nickname;
+
+    public RegisterResponse(Long userId, String username, String nickname) {
+        this.userId = userId;
+        this.username = username;
+        this.nickname = nickname;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bjtu/dining/common/config/SecurityConfig.java
@@ -1,21 +1,65 @@
 package com.bjtu.dining.common.config;
 
+import com.bjtu.dining.auth.security.JwtAuthenticationFilter;
+import com.bjtu.dining.common.enums.ErrorCode;
+import com.bjtu.dining.common.response.ApiResponse;
+import com.bjtu.dining.common.util.TraceIdUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
 
 @Configuration
 public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, ObjectMapper objectMapper) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.objectMapper = objectMapper;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        // Temporary baseline so the project can start before JWT auth is wired in.
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .cors(Customizer.withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint())
+                        .accessDeniedHandler(accessDeniedHandler())
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/register", "/api/v1/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/home/summary").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/restaurants/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/dishes/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/flows/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/ratings/targets/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/recommendations/restaurants",
+                                "/api/v1/recommendations/dishes",
+                                "/api/v1/recommendations/mixed"
+                        ).permitAll()
+                        .requestMatchers("/ws/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
@@ -23,5 +67,32 @@ public class SecurityConfig {
                 .anonymous(Customizer.withDefaults());
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            Object errorCodeAttr = request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_CODE_ATTRIBUTE);
+            ErrorCode errorCode = errorCodeAttr instanceof ErrorCode ? (ErrorCode) errorCodeAttr : ErrorCode.UNAUTHORIZED;
+            writeFailureResponse(response, errorCode);
+        };
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> writeFailureResponse(response, ErrorCode.FORBIDDEN);
+    }
+
+    private void writeFailureResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader(TraceIdUtils.TRACE_ID_HEADER, TraceIdUtils.currentTraceId());
+        objectMapper.writeValue(response.getWriter(), ApiResponse.failure(errorCode, null));
     }
 }

--- a/backend/src/main/java/com/bjtu/dining/common/enums/ErrorCode.java
+++ b/backend/src/main/java/com/bjtu/dining/common/enums/ErrorCode.java
@@ -1,0 +1,44 @@
+package com.bjtu.dining.common.enums;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    SUCCESS(0, "ok", HttpStatus.OK),
+    BAD_REQUEST(40000, "请求格式错误", HttpStatus.BAD_REQUEST),
+    VALIDATION_ERROR(40001, "参数校验失败", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED(40100, "未登录", HttpStatus.UNAUTHORIZED),
+    TOKEN_EXPIRED(40101, "Token 过期", HttpStatus.UNAUTHORIZED),
+    INVALID_CREDENTIALS(40102, "用户名或密码错误", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN(40300, "无权限", HttpStatus.FORBIDDEN),
+    NOT_FOUND(40400, "资源不存在", HttpStatus.NOT_FOUND),
+    RATING_TARGET_NOT_FOUND(40401, "评分目标不存在", HttpStatus.NOT_FOUND),
+    CONFLICT(40900, "资源状态冲突", HttpStatus.CONFLICT),
+    INSUFFICIENT_BALANCE(40901, "余额不足", HttpStatus.CONFLICT),
+    INSUFFICIENT_STOCK(40902, "菜品库存不足", HttpStatus.CONFLICT),
+    USERNAME_EXISTS(40903, "用户名已存在", HttpStatus.CONFLICT),
+    DISH_WINDOW_MISMATCH(40904, "菜品与窗口信息不匹配", HttpStatus.CONFLICT),
+    INTERNAL_ERROR(50000, "服务端异常", HttpStatus.INTERNAL_SERVER_ERROR),
+    SERVICE_UNAVAILABLE(50300, "仿真或推荐服务暂不可用", HttpStatus.SERVICE_UNAVAILABLE);
+
+    private final int code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(int code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/exception/BusinessException.java
+++ b/backend/src/main/java/com/bjtu/dining/common/exception/BusinessException.java
@@ -1,0 +1,30 @@
+package com.bjtu.dining.common.exception;
+
+import com.bjtu.dining.common.enums.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Object data;
+
+    public BusinessException(ErrorCode errorCode) {
+        this(errorCode, errorCode.getMessage(), null);
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        this(errorCode, message, null);
+    }
+
+    public BusinessException(ErrorCode errorCode, String message, Object data) {
+        super(message);
+        this.errorCode = errorCode;
+        this.data = data;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public Object getData() {
+        return data;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bjtu/dining/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.bjtu.dining.common.exception;
+
+import com.bjtu.dining.common.enums.ErrorCode;
+import com.bjtu.dining.common.response.ApiResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBusinessException(BusinessException ex) {
+        return ResponseEntity
+                .status(ex.getErrorCode().getHttpStatus())
+                .body(ApiResponse.failure(ex.getErrorCode().getCode(), ex.getMessage(), ex.getData()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        return ResponseEntity
+                .status(ErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ApiResponse.failure(ErrorCode.VALIDATION_ERROR, buildFieldErrorData(
+                        fieldError == null ? null : fieldError.getField(),
+                        fieldError == null ? "请求参数不合法" : fieldError.getDefaultMessage()
+                )));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBindException(BindException ex) {
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        return ResponseEntity
+                .status(ErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ApiResponse.failure(ErrorCode.VALIDATION_ERROR, buildFieldErrorData(
+                        fieldError == null ? null : fieldError.getField(),
+                        fieldError == null ? "请求参数不合法" : fieldError.getDefaultMessage()
+                )));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleConstraintViolationException(ConstraintViolationException ex) {
+        ConstraintViolation<?> violation = ex.getConstraintViolations().stream().findFirst().orElse(null);
+        String field = violation == null ? null : violation.getPropertyPath().toString();
+        String reason = violation == null ? "请求参数不合法" : violation.getMessage();
+        return ResponseEntity
+                .status(ErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ApiResponse.failure(ErrorCode.VALIDATION_ERROR, buildFieldErrorData(field, reason)));
+    }
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MissingServletRequestParameterException.class,
+            IllegalArgumentException.class
+    })
+    public ResponseEntity<ApiResponse<Object>> handleBadRequestException(Exception ex) {
+        return ResponseEntity
+                .status(ErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ApiResponse.failure(ErrorCode.VALIDATION_ERROR, buildFieldErrorData(null, ex.getMessage())));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception ex) {
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getHttpStatus())
+                .body(ApiResponse.failure(ErrorCode.INTERNAL_ERROR, buildFieldErrorData(null, ex.getMessage())));
+    }
+
+    private Map<String, Object> buildFieldErrorData(String field, String reason) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("field", field);
+        data.put("reason", reason);
+        return data;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/filter/TraceIdFilter.java
+++ b/backend/src/main/java/com/bjtu/dining/common/filter/TraceIdFilter.java
@@ -1,0 +1,33 @@
+package com.bjtu.dining.common.filter;
+
+import com.bjtu.dining.common.util.TraceIdUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String incomingTraceId = request.getHeader(TraceIdUtils.TRACE_ID_HEADER);
+        String traceId = TraceIdUtils.normalizeTraceId(incomingTraceId);
+
+        MDC.put(TraceIdUtils.TRACE_ID_KEY, traceId);
+        response.setHeader(TraceIdUtils.TRACE_ID_HEADER, traceId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(TraceIdUtils.TRACE_ID_KEY);
+        }
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/response/ApiResponse.java
+++ b/backend/src/main/java/com/bjtu/dining/common/response/ApiResponse.java
@@ -1,0 +1,83 @@
+package com.bjtu.dining.common.response;
+
+import com.bjtu.dining.common.enums.ErrorCode;
+import com.bjtu.dining.common.util.TraceIdUtils;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class ApiResponse<T> {
+    private final int code;
+    private final String message;
+    private final T data;
+    private final String traceId;
+    private final OffsetDateTime timestamp;
+
+    private ApiResponse(int code, String message, T data, String traceId, OffsetDateTime timestamp) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.traceId = traceId;
+        this.timestamp = timestamp;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS.getCode(),
+                ErrorCode.SUCCESS.getMessage(),
+                data,
+                TraceIdUtils.currentTraceId(),
+                OffsetDateTime.now(ZoneOffset.ofHours(8))
+        );
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS.getCode(),
+                message,
+                data,
+                TraceIdUtils.currentTraceId(),
+                OffsetDateTime.now(ZoneOffset.ofHours(8))
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(ErrorCode errorCode, T data) {
+        return new ApiResponse<>(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                data,
+                TraceIdUtils.currentTraceId(),
+                OffsetDateTime.now(ZoneOffset.ofHours(8))
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(int code, String message, T data) {
+        return new ApiResponse<>(
+                code,
+                message,
+                data,
+                TraceIdUtils.currentTraceId(),
+                OffsetDateTime.now(ZoneOffset.ofHours(8))
+        );
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public String getTraceId() {
+        return traceId;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/response/PageResponse.java
+++ b/backend/src/main/java/com/bjtu/dining/common/response/PageResponse.java
@@ -1,0 +1,37 @@
+package com.bjtu.dining.common.response;
+
+import java.util.List;
+
+public class PageResponse<T> {
+    private final List<T> list;
+    private final long total;
+    private final long page;
+    private final long pageSize;
+
+    private PageResponse(List<T> list, long total, long page, long pageSize) {
+        this.list = list;
+        this.total = total;
+        this.page = page;
+        this.pageSize = pageSize;
+    }
+
+    public static <T> PageResponse<T> of(List<T> list, long total, long page, long pageSize) {
+        return new PageResponse<>(list, total, page, pageSize);
+    }
+
+    public List<T> getList() {
+        return list;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public long getPage() {
+        return page;
+    }
+
+    public long getPageSize() {
+        return pageSize;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/common/util/TraceIdUtils.java
+++ b/backend/src/main/java/com/bjtu/dining/common/util/TraceIdUtils.java
@@ -1,0 +1,29 @@
+package com.bjtu.dining.common.util;
+
+import org.slf4j.MDC;
+
+import java.util.UUID;
+
+public final class TraceIdUtils {
+    public static final String TRACE_ID_KEY = "traceId";
+    public static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    private TraceIdUtils() {
+    }
+
+    public static String currentTraceId() {
+        String traceId = MDC.get(TRACE_ID_KEY);
+        return normalizeTraceId(traceId);
+    }
+
+    public static String normalizeTraceId(String traceId) {
+        if (traceId == null || traceId.isBlank()) {
+            return newTraceId();
+        }
+        return traceId.trim();
+    }
+
+    private static String newTraceId() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/user/controller/UserController.java
+++ b/backend/src/main/java/com/bjtu/dining/user/controller/UserController.java
@@ -1,0 +1,24 @@
+package com.bjtu.dining.user.controller;
+
+import com.bjtu.dining.auth.security.AuthUserContext;
+import com.bjtu.dining.common.response.ApiResponse;
+import com.bjtu.dining.user.service.UserService;
+import com.bjtu.dining.user.vo.UserProfileResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<UserProfileResponse> getCurrentUserProfile() {
+        return ApiResponse.success(userService.getCurrentUserProfile(AuthUserContext.currentUserId()));
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/user/entity/User.java
+++ b/backend/src/main/java/com/bjtu/dining/user/entity/User.java
@@ -1,0 +1,75 @@
+package com.bjtu.dining.user.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.time.LocalDateTime;
+
+@TableName("users")
+public class User {
+    @TableId(value = "user_id", type = IdType.AUTO)
+    private Long userId;
+    private String username;
+    private String password;
+    private String nickname;
+    private String avatarUrl;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public void setAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+    }
+
+    public LocalDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(LocalDateTime createTime) {
+        this.createTime = createTime;
+    }
+
+    public LocalDateTime getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(LocalDateTime updateTime) {
+        this.updateTime = updateTime;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/user/mapper/UserMapper.java
+++ b/backend/src/main/java/com/bjtu/dining/user/mapper/UserMapper.java
@@ -1,0 +1,9 @@
+package com.bjtu.dining.user.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.bjtu.dining.user.entity.User;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserMapper extends BaseMapper<User> {
+}

--- a/backend/src/main/java/com/bjtu/dining/user/service/UserService.java
+++ b/backend/src/main/java/com/bjtu/dining/user/service/UserService.java
@@ -1,0 +1,7 @@
+package com.bjtu.dining.user.service;
+
+import com.bjtu.dining.user.vo.UserProfileResponse;
+
+public interface UserService {
+    UserProfileResponse getCurrentUserProfile(Long userId);
+}

--- a/backend/src/main/java/com/bjtu/dining/user/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/bjtu/dining/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,27 @@
+package com.bjtu.dining.user.service.impl;
+
+import com.bjtu.dining.common.enums.ErrorCode;
+import com.bjtu.dining.common.exception.BusinessException;
+import com.bjtu.dining.user.entity.User;
+import com.bjtu.dining.user.mapper.UserMapper;
+import com.bjtu.dining.user.service.UserService;
+import com.bjtu.dining.user.vo.UserProfileResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserServiceImpl implements UserService {
+    private final UserMapper userMapper;
+
+    public UserServiceImpl(UserMapper userMapper) {
+        this.userMapper = userMapper;
+    }
+
+    @Override
+    public UserProfileResponse getCurrentUserProfile(Long userId) {
+        User user = userMapper.selectById(userId);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.NOT_FOUND);
+        }
+        return UserProfileResponse.from(user);
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/user/vo/UserProfileResponse.java
+++ b/backend/src/main/java/com/bjtu/dining/user/vo/UserProfileResponse.java
@@ -1,0 +1,52 @@
+package com.bjtu.dining.user.vo;
+
+import com.bjtu.dining.user.entity.User;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class UserProfileResponse {
+    private final Long userId;
+    private final String username;
+    private final String nickname;
+    private final String avatarUrl;
+    private final String registerTime;
+
+    public UserProfileResponse(Long userId, String username, String nickname, String avatarUrl, String registerTime) {
+        this.userId = userId;
+        this.username = username;
+        this.nickname = nickname;
+        this.avatarUrl = avatarUrl;
+        this.registerTime = registerTime;
+    }
+
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(
+                user.getUserId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getAvatarUrl(),
+                user.getCreateTime().atOffset(ZoneOffset.ofHours(8)).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        );
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public String getRegisterTime() {
+        return registerTime;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/wallet/entity/Wallet.java
+++ b/backend/src/main/java/com/bjtu/dining/wallet/entity/Wallet.java
@@ -1,0 +1,49 @@
+package com.bjtu.dining.wallet.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@TableName("wallets")
+public class Wallet {
+    @TableId(value = "wallet_id", type = IdType.AUTO)
+    private Long walletId;
+    private Long userId;
+    private BigDecimal balance;
+    private LocalDateTime updateTime;
+
+    public Long getWalletId() {
+        return walletId;
+    }
+
+    public void setWalletId(Long walletId) {
+        this.walletId = walletId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public void setBalance(BigDecimal balance) {
+        this.balance = balance;
+    }
+
+    public LocalDateTime getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(LocalDateTime updateTime) {
+        this.updateTime = updateTime;
+    }
+}

--- a/backend/src/main/java/com/bjtu/dining/wallet/mapper/WalletMapper.java
+++ b/backend/src/main/java/com/bjtu/dining/wallet/mapper/WalletMapper.java
@@ -1,0 +1,9 @@
+package com.bjtu.dining.wallet.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.bjtu.dining.wallet.entity.Wallet;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface WalletMapper extends BaseMapper<Wallet> {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -26,3 +26,9 @@ mybatis-plus:
 logging:
   level:
     root: info
+
+app:
+  security:
+    jwt:
+      secret: ${JWT_SECRET:bjtu-dining-simulation-system-jwt-secret-key-2026}
+      expire-seconds: ${JWT_EXPIRE_SECONDS:7200}

--- a/sql/schema/001_user_wallet_order_rating.sql
+++ b/sql/schema/001_user_wallet_order_rating.sql
@@ -1,0 +1,71 @@
+CREATE TABLE IF NOT EXISTS users (
+    user_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    username VARCHAR(50) NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    nickname VARCHAR(50) NOT NULL,
+    avatar_url VARCHAR(255) NOT NULL DEFAULT '',
+    create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT uk_users_username UNIQUE (username)
+);
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+    preference_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    taste_tags JSON NULL,
+    cuisine_types JSON NULL,
+    spicy_level TINYINT NOT NULL DEFAULT 0,
+    budget_min DECIMAL(10, 2) NULL,
+    budget_max DECIMAL(10, 2) NULL,
+    create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT uk_user_preferences_user UNIQUE (user_id),
+    CONSTRAINT fk_user_preferences_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+CREATE TABLE IF NOT EXISTS wallets (
+    wallet_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    balance DECIMAL(10, 2) NOT NULL DEFAULT 0.00,
+    update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT uk_wallets_user UNIQUE (user_id),
+    CONSTRAINT fk_wallets_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+CREATE TABLE IF NOT EXISTS transactions (
+    transaction_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    wallet_id BIGINT NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    amount DECIMAL(10, 2) NOT NULL,
+    balance_after DECIMAL(10, 2) NOT NULL,
+    remark VARCHAR(255) NULL,
+    create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_transactions_wallet FOREIGN KEY (wallet_id) REFERENCES wallets (wallet_id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    order_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    dish_id BIGINT NOT NULL,
+    window_id BIGINT NOT NULL,
+    restaurant_id BIGINT NOT NULL,
+    quantity INT NOT NULL,
+    total_amount DECIMAL(10, 2) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    transaction_id BIGINT NULL,
+    create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+CREATE TABLE IF NOT EXISTS ratings (
+    rating_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    target_type VARCHAR(20) NOT NULL,
+    target_id BIGINT NOT NULL,
+    score INT NOT NULL,
+    comment VARCHAR(500) NULL,
+    create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_ratings_user FOREIGN KEY (user_id) REFERENCES users (user_id),
+    CONSTRAINT uk_ratings_user_target UNIQUE (user_id, target_type, target_id)
+);


### PR DESCRIPTION
本次改动：
- 补充 common 公共底座：统一响应、异常处理、错误码、traceId
- 实现注册接口 POST /api/v1/auth/register
- 实现登录接口 POST /api/v1/auth/login
- 接入 JWT 鉴权与 Spring Security 基础配置
- 实现获取当前用户资料 GET /api/v1/users/me
- 新增成员 A 第一版建表 SQL

影响范围：
- backend/auth/
- backend/common/
- backend/user/
- backend/wallet/
- backend/src/main/resources/application.yml
- sql/schema/001_user_wallet_order_rating.sql

验证情况：
- mvn package 编译通过
- 已本地验证注册、登录、JWT、users/me 主链路
- 错误密码登录返回 40102
- 未带 token 访问 users/me 返回 40100

不涉及：
- restaurant/
- window/
- dish/
- flow/
- recommendation/
- frontend/